### PR TITLE
Import User and CurrentUser attribute

### DIFF
--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -4,17 +4,19 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class ProfileController extends AbstractController
 {
     #[Route('/api/profile', name: 'api_user_profile', methods: ['GET'])]
     #[IsGranted('ROLE_USER')]
-    public function getUserProfile(#[CurrentUser] ?User $user): JsonResponse
+    public function getUserProfile(#[CurrentUser()] ?User $user): JsonResponse
     {
         if (!$user) {
             return $this->json(['error' => 'Unauthorized'], Response::HTTP_UNAUTHORIZED);


### PR DESCRIPTION
Add use statements for App\Entity\User and Symfony\Component\Security\Http\Attribute\CurrentUser, and adjust the method attribute to #[CurrentUser()] on getUserProfile(). This ensures the CurrentUser attribute is properly referenced and the controller can type-hint the authenticated User instance.