### PR TITLE
Add user photo upload handler and storage

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -13,7 +13,8 @@ services:
     _defaults:
         autowire: true      # Automatically injects dependencies in your services.
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
-
+        bind:
+            string $userPhotosDir: '%kernel.project_dir%/public/uploads/users'
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name
     App\:

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -5,15 +5,29 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Entity\User;
+use App\Handler\UploadUserPhotoHanderInterface;
+use App\Handler\UploadUserPhotoHandler;
+use App\Service\UserPhotoStorage;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class ProfileController extends AbstractController
 {
+    public function __construct(
+        private UserPhotoStorage $photoStorage,
+        private ValidatorInterface $validationService,
+        #[Autowire(service: UploadUserPhotoHandler::class)]
+        private UploadUserPhotoHanderInterface $uploadUserPhotoHandler
+    ) {
+    }
     #[Route('/api/profile', name: 'api_user_profile', methods: ['GET'])]
     #[IsGranted('ROLE_USER')]
     public function getUserProfile(#[CurrentUser()] ?User $user): JsonResponse
@@ -23,5 +37,33 @@ class ProfileController extends AbstractController
         }
 
         return $this->json($user, Response::HTTP_OK, [], ['groups' => ['user:profile']]);
+    }
+
+    #[Route('/api/profile/photo', name: 'api_update_user_profile', methods: ['POST'])]
+    public function updateUserProfile(Request $request, #[CurrentUser()] ?User $user): JsonResponse
+    {
+        $file = $request->files->get('photo');
+
+        if (!$file instanceof UploadedFile) {
+            return $this->json(
+                ['error' => 'Missing file field "photo" (multipart/form-data).'],
+                Response::HTTP_BAD_REQUEST
+            );
+        }
+        $erros = $this->validationService->validate($file);
+        if (count($erros) > 0) {
+            $errorMessages = [];
+
+            foreach ($erros as $error) {
+                $errorMessages[] = $error->getMessage();
+            }
+            return $this->json(['errors' => $errorMessages], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        $filename = $this->photoStorage->store($file, $user->getId());
+        $this->uploadUserPhotoHandler->handle($user->getId(), $filename);
+
+        return $this->json(['message' => 'Photo uploaded successfully'], Response::HTTP_OK);
+
     }
 }

--- a/src/Handler/UploadUserPhotoHanderInterface.php
+++ b/src/Handler/UploadUserPhotoHanderInterface.php
@@ -1,0 +1,10 @@
+<?php 
+
+declare(strict_types=1);
+
+namespace App\Handler;
+
+interface UploadUserPhotoHanderInterface
+{
+    public function handle(int $userId, string $filename): void;
+}

--- a/src/Handler/UploadUserPhotoHandler.php
+++ b/src/Handler/UploadUserPhotoHandler.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Handler;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+
+class UploadUserPhotoHandler implements UploadUserPhotoHanderInterface
+{
+    public function __construct(private EntityManagerInterface $entityManager)
+    {
+    }
+    public function handle(int $userId, string $filename): void
+    {
+        $user = $this->entityManager->getRepository(User::class)->find($userId);
+        if ($user) {
+            $user->setPhoto($filename);
+            $this->entityManager->persist($user);
+            $this->entityManager->flush();
+        }
+    }
+}

--- a/src/Service/UserPhotoStorage.php
+++ b/src/Service/UserPhotoStorage.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Service;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\String\Slugger\SluggerInterface;
+
+class  UserPhotoStorage
+{
+    public function __construct(
+        private string $userPhotosDir,
+        private SluggerInterface $slugger
+    )
+    {
+    }
+    public function store(UploadedFile $file, int $userId): string
+    {
+       
+        $originalFilename = pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME);
+        $slugerNamer = strtolower((string) $this->slugger->slug($originalFilename));
+
+        $xtension = strtolower((string) $file->guessExtension());
+        if (!$xtension) {
+            $xtension = 'bin';
+        }
+
+        $filename = sprintf('user_%d_%s.%s', $userId, $slugerNamer, $xtension);
+        $file->move($this->userPhotosDir, $filename);
+
+        return $filename;
+    }
+}

--- a/tests/Handler/UploadUserPhotoHandlerTest.php
+++ b/tests/Handler/UploadUserPhotoHandlerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Tests\Handler;
+
+use App\Entity\User;
+use App\Handler\UploadUserPhotoHandler;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Monolog\Test\TestCase;
+
+class UploadUserPhotoHandlerTest extends TestCase
+{
+    public function testHandle(): void
+    {
+        $userId = 1;
+        $filename = 'user_10_avatar.webp';
+        $entityManger = $this->createMock(EntityManagerInterface::class);
+        $objectRepositoyr = $this->createMock(EntityRepository::class);
+
+        $user = $this->createMock(User::class);
+        
+        $user->expects($this->once())
+            ->method('setPhoto')
+            ->with($filename);
+
+        $objectRepositoyr->expects(self::once())
+            ->method('find')
+            ->with($userId)
+            ->willReturn($user);
+
+        $entityManger->expects($this->once())
+            ->method('getRepository')
+            ->with(User::class)
+            ->willReturn($objectRepositoyr);
+
+        $entityManger->expects($this->once())
+            ->method('persist');
+        $entityManger->expects($this->once())
+            ->method('flush');
+
+        $handler = new UploadUserPhotoHandler($entityManger);
+        $handler->handle($userId, $filename);
+    }
+
+    public function testHandleDoesNothingWhenUserNotFound(): void
+    {
+        $userId = 1;
+        $filename = 'user_10_avatar.webp';
+        $entityManger = $this->createMock(EntityManagerInterface::class);
+        $objectRepositoyr = $this->createMock(EntityRepository::class);
+
+        $objectRepositoyr->expects(self::once())
+            ->method('find')
+            ->willReturn(null);
+        $entityManger->expects($this->once())
+            ->method('getRepository')
+            ->with(User::class)
+            ->willReturn($objectRepositoyr);
+
+        $entityManger->expects($this->never())
+            ->method('persist');
+        $entityManger->expects($this->never())
+            ->method('flush');
+        $handler = new UploadUserPhotoHandler($entityManger);
+        $handler->handle($userId, $filename);
+    }
+}


### PR DESCRIPTION
Introduce profile photo upload flow: add UserPhotoStorage service to save uploaded files, an UploadUserPhotoHanderInterface and its UploadUserPhotoHandler implementation to persist the filename to the User entity, and unit tests for the handler. Update ProfileController to accept multipart POST /api/profile/photo, validate the uploaded file, store it via UserPhotoStorage and delegate DB update to the handler. Bind the userPhotosDir parameter in services.yaml for DI.